### PR TITLE
Update angular.json with eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avrios-schematics",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A blank schematics",
   "scripts": {
     "build": "tsc -p tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avrios-schematics",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "description": "A blank schematics",
   "scripts": {
     "build": "tsc -p tsconfig.json"

--- a/src/library/index.js
+++ b/src/library/index.js
@@ -35,26 +35,20 @@ function default_1(options) {
             projectType: 'library',
             schematics: {},
             prefix: 'avr',
-            architect: {
-                lint: {
-                    builder: '@angular-devkit/build-angular:tslint',
-                    options: {
-                        tsConfig: [
-                            'libs/shared/tsconfig.lib.json',
-                            'libs/shared/tsconfig.spec.json'
-                        ],
-                        exclude: [
-                            '**/node_modules/**',
-                            '!libs/shared/**/*'
-                        ]
+            "architect": {
+                "lint": {
+                    "builder": "@nrwl/linter:eslint",
+                    "options": {
+                        "lintFilePatterns": [`libs/shared/src/lib/${dasherizedName}/**/*.ts`, `libs/shared/src/lib/${dasherizedName}/**/*.html`],
+                        "eslintConfig": "libs/shared/.eslintrc.json"
                     }
                 },
-                test: {
-                    builder: '@nrwl/jest:jest',
-                    options: {
-                        jestConfig: `libs/shared/jest.config.js`,
-                        passWithNoTests: true,
-                        testPathPattern: [`lib/${dasherizedName}/`]
+                "test": {
+                    "builder": "@nrwl/jest:jest",
+                    "options": {
+                        "jestConfig": "libs/shared/jest.config.js",
+                        "passWithNoTests": true,
+                        "testPathPattern": [`lib/${dasherizedName}/`]
                     }
                 }
             }


### PR DESCRIPTION
### Jira Ticket [AV-25910](https://avrios.atlassian.net/browse/AV-25910)

### Description
- Current configuration makes ts-lint the default linter causing linting tasks to fail in `frontend-service`

### Changes
- Update to eslint

[AV-25910]: https://avrios.atlassian.net/browse/AV-25910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ