### PR TITLE
chore: Update angular to 13 and fix `id` in schema.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1159 @@
+{
+  "name": "avrios-schematics",
+  "version": "2.4.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "avrios-schematics",
+      "version": "2.4.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@angular-devkit/architect": "0.1300.1",
+        "@angular-devkit/core": "13.0.1",
+        "@angular-devkit/schematics": "13.0.1",
+        "@schematics/angular": "13.0.1",
+        "@types/node": "15.0.2",
+        "rxjs": "7.4.0",
+        "typescript": "4.4.4"
+      }
+    },
+    "node_modules/@angular-devkit/architect": {
+      "version": "0.1300.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/architect/-/architect-0.1300.1.tgz",
+      "integrity": "sha512-D6R2kYnZlKIpVx+lnuC8MRu8ZUqq2dkpeNJ1yP2IgkRdRktXWOOc2xj8utZ6NVCn8m/9kdOceQDlceVz/XT0+g==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "13.0.1",
+        "rxjs": "6.6.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@angular-devkit/core": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/core/-/core-13.0.1.tgz",
+      "integrity": "sha512-RfhpPw7vU5ok7ICUwEx4Lic+HCHrMjKnj/Tbk+CfSqONTFtqDaMoC8itQE2risLugT4mzO+3Cy95eccpf282kQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.6.3",
+        "ajv-formats": "2.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "magic-string": "0.25.7",
+        "rxjs": "6.6.7",
+        "source-map": "0.7.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@angular-devkit/schematics": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/schematics/-/schematics-13.0.1.tgz",
+      "integrity": "sha512-WEhotd5H82W8LHo9tgTh547A1pxwmcKDHLhlsko5dg/HuHHhEYuxUxlLaBs1yHl+VVPG+Cwnf3pEbVhWGHVS3Q==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "13.0.1",
+        "jsonc-parser": "3.0.0",
+        "magic-string": "0.25.7",
+        "ora": "5.4.1",
+        "rxjs": "6.6.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@schematics/angular": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@schematics/angular/-/angular-13.0.1.tgz",
+      "integrity": "sha512-Qs3vcpSmBpzIxyaihDP3rtc6ge13t8dhqq9vXzE0MCq+HRUptAPmsx7JOUiB0/3T33XGNC9ICKdpGD+6xNltgw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "13.0.1",
+        "@angular-devkit/schematics": "13.0.1",
+        "jsonc-parser": "3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "15.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@types/node/-/node-15.0.2.tgz",
+      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "dev": true
+    },
+    "node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    }
+  },
+  "dependencies": {
+    "@angular-devkit/architect": {
+      "version": "0.1300.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/architect/-/architect-0.1300.1.tgz",
+      "integrity": "sha512-D6R2kYnZlKIpVx+lnuC8MRu8ZUqq2dkpeNJ1yP2IgkRdRktXWOOc2xj8utZ6NVCn8m/9kdOceQDlceVz/XT0+g==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "13.0.1",
+        "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@angular-devkit/core": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/core/-/core-13.0.1.tgz",
+      "integrity": "sha512-RfhpPw7vU5ok7ICUwEx4Lic+HCHrMjKnj/Tbk+CfSqONTFtqDaMoC8itQE2risLugT4mzO+3Cy95eccpf282kQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "8.6.3",
+        "ajv-formats": "2.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "magic-string": "0.25.7",
+        "rxjs": "6.6.7",
+        "source-map": "0.7.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@angular-devkit/schematics": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@angular-devkit/schematics/-/schematics-13.0.1.tgz",
+      "integrity": "sha512-WEhotd5H82W8LHo9tgTh547A1pxwmcKDHLhlsko5dg/HuHHhEYuxUxlLaBs1yHl+VVPG+Cwnf3pEbVhWGHVS3Q==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "13.0.1",
+        "jsonc-parser": "3.0.0",
+        "magic-string": "0.25.7",
+        "ora": "5.4.1",
+        "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@schematics/angular": {
+      "version": "13.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@schematics/angular/-/angular-13.0.1.tgz",
+      "integrity": "sha512-Qs3vcpSmBpzIxyaihDP3rtc6ge13t8dhqq9vXzE0MCq+HRUptAPmsx7JOUiB0/3T33XGNC9ICKdpGD+6xNltgw==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "13.0.1",
+        "@angular-devkit/schematics": "13.0.1",
+        "jsonc-parser": "3.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "15.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/@types/node/-/node-15.0.2.tgz",
+      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "8.9.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.9.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "dev": true
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      }
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.7.3",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "tslib": {
+      "version": "2.1.0",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://avrios-917835067517.d.codeartifact.eu-central-1.amazonaws.com/npm/avrios-npm/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avrios-schematics",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "A blank schematics",
   "scripts": {
     "build": "tsc -p tsconfig.json"
@@ -12,13 +12,12 @@
   "license": "MIT",
   "schematics": "./src/collection.json",
   "devDependencies": {
-    "@angular-devkit/core": "^7.3.4",
-    "@angular-devkit/schematics": "^7.3.4",
-    "@schematics/angular": "^7.3.4",
-    "@types/jasmine": "^3.0.0",
-    "@types/node": "^8.0.31",
-    "jasmine": "^3.0.0",
-    "rxjs": "^6.4.0",
-    "typescript": "~3.2.2"
+    "@angular-devkit/architect": "0.1300.1",
+    "@angular-devkit/core": "13.0.1",
+    "@angular-devkit/schematics": "13.0.1",
+    "@schematics/angular": "13.0.1",
+    "@types/node": "15.0.2",
+    "rxjs": "7.4.0",
+    "typescript": "4.4.4"
   }
 }

--- a/src/api-service/index.js
+++ b/src/api-service/index.js
@@ -10,21 +10,21 @@ function default_1(options) {
         if (!options.project) {
             throw new schematics_1.SchematicsException('Option (project) is required.');
         }
-        const project = project_1.getProject(host, options.project);
+        const project = (0, project_1.getProject)(host, options.project);
         if (options.path === undefined) {
-            options.path = project_1.buildDefaultPath(project);
+            options.path = (0, project_1.buildDefaultPath)(project);
         }
-        const parsedPath = parse_name_1.parseName(options.path, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        validation_1.validateName(options.name);
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            options.skipTests ? schematics_1.filter(path => !path.endsWith('.spec.ts.template')) : schematics_1.noop(),
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        (0, validation_1.validateName)(options.name);
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            options.skipTests ? (0, schematics_1.filter)(path => !path.endsWith('.spec.ts.template')) : (0, schematics_1.noop)(),
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
-            schematics_1.mergeWith(templateSource)
+        return (0, schematics_1.chain)([
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/api-service/schema.json
+++ b/src/api-service/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "SchematicsAngularComponent",
+    "$id": "SchematicsAngularComponent",
     "title": "Angular Component Options Schema",
     "type": "object",
     "description": "Creates a new generic API service definition in the given or default project.",

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -17,26 +17,27 @@ function buildSelector(options, projectPrefix) {
 }
 function default_1(options) {
     return (host) => {
+        var _a;
         if (!options.project) {
             throw new schematics_1.SchematicsException('Option (project) is required.');
         }
-        const project = project_1.getProject(host, options.project);
+        const project = (0, project_1.getProject)(host, options.project);
         if (options.path === undefined) {
-            options.path = project_1.buildDefaultPath(project);
+            options.path = (0, project_1.buildDefaultPath)(project);
         }
-        const parsedPath = parse_name_1.parseName(options.path, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
-        validation_1.validateName(options.name);
-        validation_1.validateHtmlSelector(options.selector);
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            options.skipTests ? schematics_1.filter(path => !path.endsWith('.spec.ts.template')) : schematics_1.noop(),
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        options.selector = options.selector || buildSelector(options, (_a = project.prefix) !== null && _a !== void 0 ? _a : '');
+        (0, validation_1.validateName)(options.name);
+        (0, validation_1.validateHtmlSelector)(options.selector);
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            options.skipTests ? (0, schematics_1.filter)(path => !path.endsWith('.spec.ts.template')) : (0, schematics_1.noop)(),
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
-            schematics_1.mergeWith(templateSource)
+        return (0, schematics_1.chain)([
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -52,7 +52,7 @@ export default function (options: ComponentOptions): Rule {
         const parsedPath = parseName(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
+        options.selector = options.selector || buildSelector(options, project.prefix ?? '');
 
         validateName(options.name);
         validateHtmlSelector(options.selector);

--- a/src/component/schema.json
+++ b/src/component/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "SchematicsAngularComponent",
+    "$id": "SchematicsAngularComponent",
     "title": "Angular Component Options Schema",
     "type": "object",
     "description": "Creates a new generic component definition in the given or default project.",

--- a/src/library/index.js
+++ b/src/library/index.js
@@ -11,10 +11,10 @@ function default_1(options) {
     return (host) => {
         const dasherizedName = core_1.strings.dasherize(options.name);
         const libSrcPath = `libs/shared/src/lib/${dasherizedName}`;
-        const parsedPath = parse_name_1.parseName(libSrcPath, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(libSrcPath, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        validation_1.validateName(options.name);
+        (0, validation_1.validateName)(options.name);
         const workspaceConfig = host.read(angularConfigFile);
         const nxWorkspaceConfig = host.read(nxConfigFile);
         const tsConfig = host.read(tsBaseFile);
@@ -35,20 +35,26 @@ function default_1(options) {
             projectType: 'library',
             schematics: {},
             prefix: 'avr',
-            "architect": {
-                "lint": {
-                    "builder": "@nrwl/linter:eslint",
-                    "options": {
-                        "lintFilePatterns": [`libs/shared/src/lib/${dasherizedName}/**/*.ts`, `libs/shared/src/lib/${dasherizedName}/**/*.html`],
-                        "eslintConfig": "libs/shared/.eslintrc.json"
+            architect: {
+                lint: {
+                    builder: '@angular-devkit/build-angular:tslint',
+                    options: {
+                        tsConfig: [
+                            'libs/shared/tsconfig.lib.json',
+                            'libs/shared/tsconfig.spec.json'
+                        ],
+                        exclude: [
+                            '**/node_modules/**',
+                            '!libs/shared/**/*'
+                        ]
                     }
                 },
-                "test": {
-                    "builder": "@nrwl/jest:jest",
-                    "options": {
-                        "jestConfig": "libs/shared/jest.config.js",
-                        "passWithNoTests": true,
-                        "testPathPattern": [`lib/${dasherizedName}/`]
+                test: {
+                    builder: '@nrwl/jest:jest',
+                    options: {
+                        jestConfig: `libs/shared/jest.config.js`,
+                        passWithNoTests: true,
+                        testPathPattern: [`lib/${dasherizedName}/`]
                     }
                 }
             }
@@ -62,7 +68,7 @@ function default_1(options) {
             if (!tsConfigParsed.compilerOptions.paths) {
                 tsConfigParsed.compilerOptions.paths = {};
             }
-            tsConfigParsed.compilerOptions.paths[`@shared/${libId}/*`] = [`libs/shared/src/lib/${libId}/*`];
+            tsConfigParsed.compilerOptions.paths[`@shared/${dasherizedName}/*`] = [`libs/shared/src/lib/${dasherizedName}/*`];
             host.overwrite(tsBaseFile, JSON.stringify(tsConfigParsed, null, 2));
         }
         else {
@@ -70,14 +76,14 @@ function default_1(options) {
         }
         host.overwrite(angularConfigFile, JSON.stringify(workspace));
         host.overwrite(nxConfigFile, JSON.stringify(nxWorkspace, null, 2));
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            options.skipTests ? schematics_1.filter(path => !path.endsWith('.spec.ts.template')) : schematics_1.noop(),
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            options.skipTests ? (0, schematics_1.filter)(path => !path.endsWith('.spec.ts.template')) : (0, schematics_1.noop)(),
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
+        return (0, schematics_1.chain)([
             _ => host,
-            schematics_1.mergeWith(templateSource)
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { experimental, strings } from '@angular-devkit/core';
+import { strings } from '@angular-devkit/core';
 import {
     Rule,
     SchematicsException,
@@ -80,7 +80,7 @@ export default function (options: LibraryOptions): Rule {
         const workspaceContent = workspaceConfig.toString();
         const nxWorkspaceContent = nxWorkspaceConfig.toString();
 
-        const workspace: experimental.workspace.WorkspaceSchema = JSON.parse(workspaceContent);
+        const workspace = JSON.parse(workspaceContent);
         const nxWorkspace: NxWorkspaceSchema = JSON.parse(nxWorkspaceContent);
 
         const libId = `shared-${dasherizedName}`;

--- a/src/library/schema.json
+++ b/src/library/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "SchematicsAngularComponent",
+    "$id": "SchematicsAngularComponent",
     "title": "Angular Library Options Schema",
     "type": "object",
     "description": "Creates a new generic Library definition in the given or default project.",

--- a/src/modal/index.js
+++ b/src/modal/index.js
@@ -17,26 +17,27 @@ function buildSelector(options, projectPrefix) {
 }
 function default_1(options) {
     return (host) => {
+        var _a;
         if (!options.project) {
             throw new schematics_1.SchematicsException('Option (project) is required.');
         }
-        const project = project_1.getProject(host, options.project);
+        const project = (0, project_1.getProject)(host, options.project);
         if (options.path === undefined) {
-            options.path = project_1.buildDefaultPath(project);
+            options.path = (0, project_1.buildDefaultPath)(project);
         }
-        const parsedPath = parse_name_1.parseName(options.path, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
-        validation_1.validateName(options.name);
-        validation_1.validateHtmlSelector(options.selector);
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            options.skipTests ? schematics_1.filter(path => !path.endsWith('.spec.ts.template')) : schematics_1.noop(),
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        options.selector = options.selector || buildSelector(options, (_a = project.prefix) !== null && _a !== void 0 ? _a : '');
+        (0, validation_1.validateName)(options.name);
+        (0, validation_1.validateHtmlSelector)(options.selector);
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            options.skipTests ? (0, schematics_1.filter)(path => !path.endsWith('.spec.ts.template')) : (0, schematics_1.noop)(),
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
-            schematics_1.mergeWith(templateSource)
+        return (0, schematics_1.chain)([
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/modal/index.ts
+++ b/src/modal/index.ts
@@ -52,7 +52,7 @@ export default function (options: ComponentOptions): Rule {
         const parsedPath = parseName(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
+        options.selector = options.selector || buildSelector(options, project.prefix ?? '');
 
         validateName(options.name);
         validateHtmlSelector(options.selector);

--- a/src/modal/schema.json
+++ b/src/modal/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularComponent",
+  "$id": "SchematicsAngularComponent",
   "title": "Angular Component Options Schema",
   "type": "object",
   "description": "Creates a new generic component definition in the given or default project.",

--- a/src/page-component/index.js
+++ b/src/page-component/index.js
@@ -17,26 +17,27 @@ function buildSelector(options, projectPrefix) {
 }
 function default_1(options) {
     return (host) => {
+        var _a;
         if (!options.project) {
             throw new schematics_1.SchematicsException('Option (project) is required.');
         }
-        const project = project_1.getProject(host, options.project);
+        const project = (0, project_1.getProject)(host, options.project);
         if (options.path === undefined) {
-            options.path = project_1.buildDefaultPath(project);
+            options.path = (0, project_1.buildDefaultPath)(project);
         }
-        const parsedPath = parse_name_1.parseName(options.path, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
-        validation_1.validateName(options.name);
-        validation_1.validateHtmlSelector(options.selector);
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            options.skipTests ? schematics_1.filter(path => !path.endsWith('.spec.ts.template')) : schematics_1.noop(),
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        options.selector = options.selector || buildSelector(options, (_a = project.prefix) !== null && _a !== void 0 ? _a : '');
+        (0, validation_1.validateName)(options.name);
+        (0, validation_1.validateHtmlSelector)(options.selector);
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            options.skipTests ? (0, schematics_1.filter)(path => !path.endsWith('.spec.ts.template')) : (0, schematics_1.noop)(),
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
-            schematics_1.mergeWith(templateSource)
+        return (0, schematics_1.chain)([
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/page-component/index.ts
+++ b/src/page-component/index.ts
@@ -52,7 +52,7 @@ export default function (options: ComponentOptions): Rule {
         const parsedPath = parseName(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        options.selector = options.selector || buildSelector(options, project.prefix);
+        options.selector = options.selector || buildSelector(options, project.prefix ?? '');
 
         validateName(options.name);
         validateHtmlSelector(options.selector);

--- a/src/page-component/schema.json
+++ b/src/page-component/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "SchematicsAngularComponent",
+    "$id": "SchematicsAngularComponent",
     "title": "Angular Component Options Schema",
     "type": "object",
     "description": "Creates a new page component definition in the given or default project.",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,20 +10,20 @@ function default_1(options) {
         if (!options.project) {
             throw new schematics_1.SchematicsException('Option (project) is required.');
         }
-        const project = project_1.getProject(host, options.project);
+        const project = (0, project_1.getProject)(host, options.project);
         if (options.path === undefined) {
-            options.path = project_1.buildDefaultPath(project);
+            options.path = (0, project_1.buildDefaultPath)(project);
         }
-        const parsedPath = parse_name_1.parseName(options.path, options.name);
+        const parsedPath = (0, parse_name_1.parseName)(options.path, options.name);
         options.name = parsedPath.name;
         options.path = parsedPath.path;
-        validation_1.validateName(options.name);
-        const templateSource = schematics_1.apply(schematics_1.url('./files'), [
-            schematics_1.applyTemplates(Object.assign({}, core_1.strings, options)),
-            schematics_1.move(parsedPath.path),
+        (0, validation_1.validateName)(options.name);
+        const templateSource = (0, schematics_1.apply)((0, schematics_1.url)('./files'), [
+            (0, schematics_1.applyTemplates)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(parsedPath.path),
         ]);
-        return schematics_1.chain([
-            schematics_1.mergeWith(templateSource)
+        return (0, schematics_1.chain)([
+            (0, schematics_1.mergeWith)(templateSource)
         ]);
     };
 }

--- a/src/store/schema.json
+++ b/src/store/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularNgrxStore",
+  "$id": "SchematicsAngularNgrxStore",
   "title": "Angular Store Options Schema",
   "type": "object",
   "description": "Creates a new generic ngrx store definition in the given or default project.",

--- a/src/utilities/config.js
+++ b/src/utilities/config.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAppFromConfig = exports.getConfig = exports.configPath = exports.updateWorkspace = exports.getWorkspace = exports.getWorkspacePath = void 0;
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -7,7 +8,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-const core_1 = require("@angular-devkit/core");
+const parser_1 = require("@angular-devkit/core/src/json/parser");
 const schematics_1 = require("@angular-devkit/schematics");
 function getWorkspacePath(host) {
     const possibleFiles = ['/angular.json', '/.angular.json'];
@@ -22,24 +23,9 @@ function getWorkspace(host) {
         throw new schematics_1.SchematicsException(`Could not find (${path})`);
     }
     const content = configBuffer.toString();
-    return core_1.parseJson(content, core_1.JsonParseMode.Loose);
+    return (0, parser_1.parseJson)(content, parser_1.JsonParseMode.Loose);
 }
 exports.getWorkspace = getWorkspace;
-function addProjectToWorkspace(workspace, name, project) {
-    return (_host, _context) => {
-        if (workspace.projects[name]) {
-            throw new Error(`Project '${name}' already exists in workspace.`);
-        }
-        // Add project to workspace.
-        workspace.projects[name] = project;
-        if (!workspace.defaultProject && Object.keys(workspace.projects).length === 1) {
-            // Make the new project the default one.
-            workspace.defaultProject = name;
-        }
-        return updateWorkspace(workspace);
-    };
-}
-exports.addProjectToWorkspace = addProjectToWorkspace;
 function updateWorkspace(workspace) {
     return (host, _context) => {
         host.overwrite(getWorkspacePath(host), JSON.stringify(workspace, null, 2));
@@ -52,7 +38,7 @@ function getConfig(host) {
     if (configBuffer === null) {
         throw new schematics_1.SchematicsException('Could not find .angular-cli.json');
     }
-    const config = core_1.parseJson(configBuffer.toString(), core_1.JsonParseMode.Loose);
+    const config = (0, parser_1.parseJson)(configBuffer.toString(), parser_1.JsonParseMode.Loose);
     return config;
 }
 exports.getConfig = getConfig;

--- a/src/utilities/config.ts
+++ b/src/utilities/config.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonParseMode, parseJson } from '@angular-devkit/core';
+import { JsonParseMode, parseJson } from '@angular-devkit/core/src/json/parser';
 import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
-import { ProjectType, WorkspaceProject, WorkspaceSchema } from './workspace-models';
+import { WorkspaceSchema } from './workspace-models';
 
 // The interfaces below are generated from the Angular CLI configuration schema
 // https://github.com/angular/angular-cli/blob/master/packages/@angular/cli/lib/config/schema.json
@@ -494,29 +494,6 @@ export function getWorkspace(host: Tree): WorkspaceSchema {
   const content = configBuffer.toString();
 
   return parseJson(content, JsonParseMode.Loose) as {} as WorkspaceSchema;
-}
-
-export function addProjectToWorkspace<TProjectType extends ProjectType = ProjectType.Application>(
-  workspace: WorkspaceSchema,
-  name: string,
-  project: WorkspaceProject<TProjectType>,
-): Rule {
-  return (_host: Tree, _context: SchematicContext) => {
-
-    if (workspace.projects[name]) {
-      throw new Error(`Project '${name}' already exists in workspace.`);
-    }
-
-    // Add project to workspace.
-    workspace.projects[name] = project;
-
-    if (!workspace.defaultProject && Object.keys(workspace.projects).length === 1) {
-      // Make the new project the default one.
-      workspace.defaultProject = name;
-    }
-
-    return updateWorkspace(workspace);
-  };
 }
 
 export function updateWorkspace(workspace: WorkspaceSchema): Rule {

--- a/src/utilities/parse-name.js
+++ b/src/utilities/parse-name.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseName = void 0;
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -10,11 +11,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 // import { relative, Path } from "../../../angular_devkit/core/src/virtual-fs";
 const core_1 = require("@angular-devkit/core");
 function parseName(path, name) {
-    const nameWithoutPath = core_1.basename(core_1.normalize(name));
-    const namePath = core_1.dirname(core_1.join(core_1.normalize(path), name));
+    const nameWithoutPath = (0, core_1.basename)((0, core_1.normalize)(name));
+    const namePath = (0, core_1.dirname)((0, core_1.join)((0, core_1.normalize)(path), name));
     return {
         name: nameWithoutPath,
-        path: core_1.normalize('/' + namePath),
+        path: (0, core_1.normalize)('/' + namePath),
     };
 }
 exports.parseName = parseName;

--- a/src/utilities/project.js
+++ b/src/utilities/project.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isWorkspaceProject = exports.isWorkspaceSchema = exports.getProject = exports.buildDefaultPath = void 0;
 const config_1 = require("./config");
 const workspace_models_1 = require("./workspace-models");
 /**
@@ -17,7 +18,7 @@ exports.buildDefaultPath = buildDefaultPath;
 function getProject(workspaceOrHost, projectName) {
     const workspace = isWorkspaceSchema(workspaceOrHost)
         ? workspaceOrHost
-        : config_1.getWorkspace(workspaceOrHost);
+        : (0, config_1.getWorkspace)(workspaceOrHost);
     return workspace.projects[projectName];
 }
 exports.getProject = getProject;

--- a/src/utilities/validation.js
+++ b/src/utilities/validation.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.validateHtmlSelector = exports.htmlSelectorRe = exports.validateName = void 0;
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.

--- a/src/utilities/workspace-models.js
+++ b/src/utilities/workspace-models.js
@@ -7,6 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Builders = exports.ProjectType = void 0;
 var ProjectType;
 (function (ProjectType) {
     ProjectType["Application"] = "application";

--- a/src/utilities/workspace-models.ts
+++ b/src/utilities/workspace-models.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { experimental } from '@angular-devkit/core';
+import { ProjectDefinition } from '@angular-devkit/core/src/workspace/definitions';
 
 export enum ProjectType {
     Application = 'application',
@@ -126,14 +126,14 @@ export type ServeBuilderTarget = BuilderTarget<Builders.DevServer, ServeBuilderO
 export type ExtractI18nBuilderTarget = BuilderTarget<Builders.ExtractI18n, ExtractI18nOptions>;
 export type E2EBuilderTarget = BuilderTarget<Builders.Protractor, E2EOptions>;
 
-export interface WorkspaceSchema extends experimental.workspace.WorkspaceSchema {
+export interface WorkspaceSchema {
     projects: {
         [key: string]: WorkspaceProject<ProjectType.Application | ProjectType.Library>;
     };
 }
 
 export interface WorkspaceProject<TProjectType extends ProjectType = ProjectType.Application>
-    extends experimental.workspace.WorkspaceProject {
+    extends ProjectDefinition {
     /**
     * Project type.
     */
@@ -143,10 +143,6 @@ export interface WorkspaceProject<TProjectType extends ProjectType = ProjectType
      * Tool options.
      */
     architect?: WorkspaceTargets<TProjectType>;
-    /**
-     * Tool options.
-     */
-    targets?: WorkspaceTargets<TProjectType>;
 }
 
 export interface WorkspaceTargets<TProjectType extends ProjectType = ProjectType.Application> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     "strictNullChecks": true,
     "target": "es6",
     "types": [
-      "jasmine",
       "node"
     ]
   },


### PR DESCRIPTION
I don't know much about this schematics lib, but with these changes, it runs as a charm locally

<img width="1240" alt="Screenshot 2023-05-10 at 17 47 15" src="https://github.com/avrios/angular-schematics/assets/81745224/5f88050b-cbd8-4574-9543-1733d73a31a2">

JIRA-Ticket: AV-26330